### PR TITLE
Parsing body for www-urlencoded was unescaped twice

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -364,8 +364,7 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         :returns: a dict of lists
 
         """
-        expanded = unquote_utf8(qs)
-        parsed = parse_qs(expanded)
+        parsed = parse_qs(qs, encoding='utf-8')
         result = {}
         for k in parsed:
             result[k] = list(map(decode_utf8, parsed[k]))

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -369,8 +369,8 @@ def test_HTTPrettyRequest_invalid_json_body():
 def test_HTTPrettyRequest_queryparam():
     """ A content-type of x-www-form-urlencoded with a valid queryparam body should return parsed content """
     header = TEST_HEADER % {'content_type': 'application/x-www-form-urlencoded'}
-    valid_queryparam = u"hello=world&this=isavalidquerystring"
-    valid_results = {'hello': ['world'], 'this': ['isavalidquerystring']}
+    valid_queryparam = u"hello=world&this=isavalidquerystring&with=escape%20sequences%2Band+spaces"
+    valid_results = {'hello': ['world'], 'this': ['isavalidquerystring'], 'with': ['escape sequences+and spaces']}
     request = HTTPrettyRequest(header, valid_queryparam)
     expect(request.parsed_body).to.equal(valid_results)
 


### PR DESCRIPTION
The body content was parsed twice for escape sequences, resulting %2B code for + sign first to be converted to a +, then to a space